### PR TITLE
Change repo from CreeperHost url to official SpongePowered url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,7 @@ buildscript {
         maven { url = 'https://files.minecraftforge.net/maven' }
         jcenter()
         mavenCentral()
-        maven {url='https://dist.creeper.host/Sponge/maven'}
-
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
-        jcenter()
         mavenCentral()
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }


### PR DESCRIPTION
This PR changes the repository used for MixinGradle from the CreeperHost URL to the official SpongePowered URL. Fixes issues relating to not being able to download MixinGradle.

<details>
<summary>Image of a conversation from the <tt>#non-api-modding</tt> of the Forge Project discord</summary>
<img src="https://user-images.githubusercontent.com/21304337/110321545-ca030f00-804c-11eb-8e86-11566ebe0f57.png">
</details>